### PR TITLE
User doc MP2 - first draft, following CC documentation

### DIFF
--- a/source/user/cc.rst
+++ b/source/user/cc.rst
@@ -6,6 +6,10 @@ Coupled-cluster theory
 
 *Modules*: :mod:`cc`, :mod:`pbc.cc`
 
+The interfaces to coupled cluster and MP2 calculations look very similar
+in PySCF.  Therefore, note the similarities of this section to the
+:ref:`theory_mp2` documentation.
+
 Introduction
 ============
 Coupled-cluster (CC) theory is a post-Hartree-Fock method capable of describing
@@ -28,13 +32,16 @@ A minimal example of a CCSD and CCSD(T) calculation is as follows::
         symmetry = True,
     )
     mf = scf.HF(mol).run()
+    # Note that the line following these comments could be replaced by
+    # mycc = cc.CCSD(mf)
+    # mycc.kernel()
     mycc = cc.CCSD(mf).run()
     print('CCSD total energy', mycc.e_tot)
     et = mycc.ccsd_t()
     print('CCSD(T) total energy', mycc.e_tot + et)
 
 Spin symmetry
-===============
+=============
 The CC module in PySCF supports a number of broken spin symmetry reference
 wavefunctions.  In particular, CC can be performed with a spin-restricted,
 spin-unrestricted, and general (spin-mixed) Hartree-Fock solution, leading
@@ -95,8 +102,10 @@ use the ``frozen`` keyword argument::
 To freeze occupied and/or unoccupied orbitals with finer control, a list of
 0-based orbital indices can be provided as the ``frozen`` keyword argument::
     
-    mycc = cc.CCSD(mf, frozen=[0,1]).run() # freeze 2 core orbitals
-    mycc = cc.CCSD(mf, frozen=[0,1,16,17,18]).run() # freeze 2 core orbitals and 3 unoccupied orbitals
+    # freeze 2 core orbitals
+    mycc = cc.CCSD(mf, frozen=[0,1]).run()
+    # freeze 2 core orbitals and 3 unoccupied orbitals
+    mycc = cc.CCSD(mf, frozen=[0,1,16,17,18]).run()
 
 
 Equation-of-motion coupled-cluster theory 

--- a/source/user/mp.rst
+++ b/source/user/mp.rst
@@ -5,18 +5,134 @@ Second-Order Møller–Plesset Perturbation Theory
 
 *Modules*: :mod:`mp`, :mod:`pbc.mp`
 
+The interfaces to coupled cluster and MP2 calculations look very similar
+in PySCF.  Therefore, note the similarities of this section to the
+:ref:`theory_cc` documentation.
+
+
+Introduction
+============
+
+Second-Order Møller–Plesset Perturbation Theory (MP2) :cite:`Moller1934`
+is a post-Hartree--Fock method.
+
+A simple example (see :source:`examples/mp/00-simple_mp2.py`) of running
+an MP2 calculation is
+
+.. literalinclude:: ../../examples/mp/00-simple_mp2.py
+
+which outputs
+
+.. code::
+
+  converged SCF energy = -99.9873974403487
+  E(MP2) = -100.198764900659  E_corr = -0.211367460310054
+
+the Hartree--Fock energy, the MP2 energy and their difference, the
+MP2 correlation energy.
+
+.. note::
+
+  The last line in the code example above could have been replaced by
+
+  .. code ::
+    
+    pyscf.mp.MP2(mf).kernel()
+  
+  for the same result.
+
+
+Spin symmetry
+=============
+
+The MP2 module in PySCF supports a number of broken spin symmetry reference
+wavefunctions.  In particular, MP2 can be performed with a spin-restricted,
+spin-unrestricted, and general (spin-mixed) Hartree-Fock solution, leading
+to the RMP2, UMP2, and GMP2 methods.
+
+The module-level ``mp.MP2(mf)`` constructor can infer the correct method based
+on the level of symmetry-breaking in the mean-field argument.  For more explicit
+control or inspection, the respective classes and functions can be found in
+``mp2.py`` (restricted), ``ump2.py`` (unrestricted), and ``gmp2.py``
+(general).
+
+For example, a spin-unrestricted calculation on triplet oxygen can be performed
+as follows::
+
+    from pyscf import gto, scf, mp
+    mol = gto.M(
+        atom = 'O 0 0 0; O 0 0 1.2',  # in Angstrom
+        basis = 'ccpvdz',
+        spin = 2
+    )
+    mf = scf.HF(mol).run() # this is UHF
+    mymp = mp.MP2(mf).run() # this is UMP2
+    print('UMP2 total energy = ', mymp.e_tot)
+
+
+Properties
+==========
+
+A number of properties are available at the MP2 level.
+
+Unrelaxed 1- and 2-electron reduced density matrices can be calculated. 
+They are returned in the MO basis::
+
+    dm1 = mymp.make_rdm1()
+    dm2 = mymp.make_rdm2()
+
+Gradients (see e.g. :cite:`Pople1979`, :cite:`Handy1985` for MP2 gradients)
+can be calculated::
+
+    from pyscf import grad
+    mygrad = mymp.Gradients()
+    grad = mygrad.kernel()
+
+
+Frozen orbitals
+===============
+
+By default, MP2 calculations are performed in PySCF without any frozen
+orbitals, including core orbitals. To freeze the lowest-energy core
+orbitals, use the ``frozen`` keyword argument::
+
+    mymp = mp.MP2(mf, frozen=2).run()
+
+To freeze occupied and/or unoccupied orbitals with finer control, a
+list of 0-based orbital indices can be provided as the ``frozen``
+keyword argument::
+    
+    # freeze 2 core orbitals
+    mymp = mp.MP2(mf, frozen=[0,1]).run()
+    # freeze 2 core orbitals and 3 unoccupied orbitals
+    mymp = mp.MP2(mf, frozen=[0,1,16,17,18]).run()
+
+
+Job control
+===========
+
+Saving memory
+-------------
+If the t2 amplitudes are not required after the MP2 calculation, they
+don't need to be saved.  This can be set by setting the ``with_t2``
+keyword argument::
+
+    mymp = mp.MP2(mf)
+    # set with_t2 to False to not save t2 amplitudes (default is True)
+    mymp.kernel(with_t2=False)
 
 
 MP2 and MO integral transformation
-----------------------------------
+==================================
+
 For the triplet
-state, we can write a function to compute the correlation energy
+state, we can write a function to compute the correlation energy as
 
 .. math::
 
-  E_{corr} = \frac{1}{4}\sum_{ijab}
+  E_{\text{corr}} = \frac{1}{4}\sum_{ijab}
            \frac{\langle ij||ab \rangle \langle ab||ij \rangle}
-           {\epsilon_i + \epsilon_j - \epsilon_a - \epsilon_b}
+           {\epsilon_i + \epsilon_j - \epsilon_a - \epsilon_b}.
 
 .. code:: python
 
@@ -52,7 +168,8 @@ state, we can write a function to compute the correlation energy
 In this example, we concatenate :math:`\alpha` and :math:`\beta` orbitals to
 mimic the spin-orbitals.  After integral transformation, we zeroed out the
 integrals of different spin.  Here, the :mod:`ao2mo` module provides the general
-2-electron MO integral transformation.  Using this module, you are able to do
+2-electron MO integral transformation, using chemist's notation for the
+integrals.  Using this module, you are able to do
 *arbitrary* integral transformation for *arbitrary* integrals. For example, the
 following code gives the ``(ov|vv)`` type integrals::
 
@@ -89,3 +206,10 @@ analytical gradients of 2-electron integrals
   >>> eri = eri.reshape(3, nocc, nvir, nocc, nvir)
   >>> print(eri.shape)
   (3, 8, 20, 8, 20)
+
+
+References
+==========
+
+.. bibliography:: ref_mp.bib
+   :style: unsrt

--- a/source/user/ref_mp.bib
+++ b/source/user/ref_mp.bib
@@ -1,0 +1,34 @@
+@article{Handy1985,
+  title   = {The elimination of singularities in derivative calculations},
+  journal = {Chemical Physics Letters},
+  volume  = {120},
+  number  = {2},
+  pages   = {151-158},
+  year    = {1985},
+  issn    = {0009-2614},
+  doi     = {https://doi.org/10.1016/0009-2614(85)87031-7},
+  author  = {Handy, N. C. and Amos, R. D. and Gaw, J. F. and Rice, J. E. and Simandiras, E. D.}
+}
+@article{Moller1934,
+  title     = {Note on an Approximation Treatment for Many-Electron Systems},
+  author    = {M\o{}ller, C. and Plesset, M. S.},
+  journal   = {Phys. Rev.},
+  volume    = {46},
+  issue     = {7},
+  pages     = {618--622},
+  numpages  = {0},
+  year      = {1934},
+  month     = {Oct},
+  publisher = {American Physical Society},
+  doi       = {10.1103/PhysRev.46.618}
+}
+@article{Pople1979,
+  author  = {Pople, J. A. and Krishnan, R. and Schlegel, H. B. and Binkley, J. S.},
+  title   = {Derivative studies in hartree-fock and møller-plesset theories},
+  journal = {International Journal of Quantum Chemistry},
+  volume  = {16},
+  number  = {S13},
+  pages   = {225-241},
+  doi     = {https://doi.org/10.1002/qua.560160825},
+  year    = {1979}
+}


### PR DESCRIPTION
MP2 user documentation, closely follows/shares text with coupled cluster user docs.
- I have added some references but I am sure more are missing. Please direct me to relevant papers if you think they should be included or feel free to delete references I have added.
- I'd also be happy to add more sections if desired.
- Maybe not part of this pull request, but in the future importing tested code snippets might be nice.