### PR TITLE
Updating the user guide for MCSCF module

### DIFF
--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -75,7 +75,7 @@ There are four strategies and all require that you specify the number of electro
 
 
 2) Specifying the molecular orbital (MO) index of the active space orbitals you want. 
-  The user can "manually" selects the MO orbital indices (in a 1-based indexing scheme) and passes them to the ``sort_mo`` function.
+The user can "manually" select the MO orbital indices (in a 1-based indexing scheme) and pass them to the ``sort_mo`` function.
   See :source:`examples/mcscf/10-define_cas_space.py` for more details.
 
 .. code-block:: python

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -102,7 +102,7 @@ Below is a list of several general strategies one could employ to pick active sp
   In such cases, orbitals from density functional calculations often yield better starting points for CAS calculations.
 
  2) Specifying the active space orbitals as a list of molecular orbital (MO) indices. 
-  This is often useful after selecting (and typically visualizing) localized orbitals.
+   This is often useful combined with a visual analysis of localized orbitals (see the section on localized orbitals).
   The user can "manually" select the MO orbital indices (in a 1-based indexing scheme) and pass them to the ``sort_mo`` function.
   See :source:`examples/mcscf/10-define_cas_space.py` and :source:`examples/mcscf/34-init_guess_localization.py` for more details.
 

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -103,7 +103,7 @@ Below is a list of several general strategies one could employ to pick active sp
 
  2) Specifying the active space orbitals as a list of molecular orbital (MO) indices. 
    This is often useful combined with a visual analysis of localized orbitals (see the section on localized orbitals).
-  The user can "manually" select the MO orbital indices (in a 1-based indexing scheme) and pass them to the ``sort_mo`` function.
+  The user can select the MO orbital indices "manually" and pass them to the ``sort_mo`` function. NB! The orbitals are numbered from 1, not 0.
   See :source:`examples/mcscf/10-define_cas_space.py` and :source:`examples/mcscf/34-init_guess_localization.py` for more details.
 
 .. code-block:: python

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -214,7 +214,7 @@ Initial guess orbitals for the CASSCF calculation may be passed to the ``kernel`
   mycas.kernel(my_custom_mos)
 
 
-CI coefficient from previous or related calculations can also be passed as an initial guess to expedite a calculation:
+CI coefficients from a previous calculation can also be passed as an initial guess to expedite the calculation:
 
 .. code-block:: python
   mycas = mcscf.CASSCF(myhf, 8, 8)

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -161,7 +161,8 @@ For more details, see :source:`examples/mcscf/43-avas.py` and :source:`examples/
 Frozen-orbital MCSCF
 -----------------
 
-To reduce to computational expense of CASSCF calculations, users can "freeze" orbitals thereby excluding them from optimization.
+Orbitals can be frozen in the orbital optimization to e.g. reduce the computational effort of CASSCF calculations.
+The orbitals will remain fixed throughout the optimization.
 
 Users can specify the number of lowest orbitals to freeze:
 

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -321,10 +321,11 @@ The ``analyze`` member functions of MCSCF objects prints many useful properties 
 Natural Orbitals
 """"""""""""""""
 
-Energy of CAS state is invariant under orbital rotation within inactive, active, and virtual sectors.
-Inactive and virtual orbitals are by default canonicalized, i.e. they transformed such that Fock matrices within virtual and inactive sectors are diagonal, and orbital energy can be assigned to these orbitals.
-By default active orbitals are kept untouched after orbital optimization and strictly speaking no energy or electron occupation can be assigned to them.
-Users can request that active orbitals be transformed to the so-called natural representation, such that the one-body density matrix is diagonal and electron occupation can be assigned to them.
+The CAS wave function is invariant under orbital rotation within the inactive core, active, and inactive virtual spaces.
+The inactive core and virtual orbitals are by default canonicalized, i.e., they are transformed by block-diagonalizing the generalized Fock matrix within the inactive core and virtual subblocks.
+This also yields energy eigenvalues for the inactive core and virtual orbitals.
+In contrast, no energy or electron occupation can be assigned to the active orbitals, strictly speaking.
+The user may request the active orbitals to be transformed to the so-called natural representation, in which the reduced one-body density matrix is diagonal, and the formal natural orbital occupation numbers can be found on its diagonal.
 
 .. warning::
   When ``mycas.natorb`` is set, the natural orbitals may NOT be sorted by the active space occupancy.

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -1,4 +1,4 @@
-.. _theory_mcscf:
+.. _user_mcscf:
 
 Multi-configuration self-consistent field (MCSCF)
 *************************************************
@@ -6,52 +6,294 @@ Multi-configuration self-consistent field (MCSCF)
 *Modules*: :mod:`mcscf`
 
 
+Introduction
+------------
 
-Symmetry in CASSCF
-------------------
+Multiconfigurational self-consistent field (MCSCF) methods extend Hartree-Fock (HF) theory by describing the wave function as a linear combination of determinants. 
+Unlike full configuration interaction (FCI), described in :numref:`theory_ci`, complete active space (CAS) methods perform the FCI procedure on a subset of the molecular orbitals, referred to as the "active space." 
+These methods are crucial for systems that exhibit strong electron correlation, such as transition metal complexes.
+For a detailed discussion of MCSCF methods, we direct the reader to :cite:`Helgaker2013` and :cite:`esqc`.
 
-.. literalinclude:: /../examples/mcscf/21-nosymhf_then_symcasscf.py
+The MCSCF module has two main flavors: CASCI and CASSCF. 
+CASCI uses the single reference orbitals from a HF calculation and solves the CI eigenvalue problem once.
+CASSCF calculations optimize the orbitals for the set of determinants and require solving the CI eigenvalue multiple (and possibly many) times.
 
-To restart a CASSCF calculation, you need prepare either CASSCF orbitals
-or CI coefficients (not that useful unless doing a DMRG-CASSCF calculation) or
-both.  For example:
+Minimal examples for each type of calculations are shown below.
 
-.. literalinclude:: /../examples/mcscf/13-restart.py
+CASCI
+"""""
+.. code-block:: python
+
+  import pyscf
+  mol = pyscf.M(
+      atom = 'O 0 0 0; O 0 0 1.2',
+      basis = 'ccpvdz',
+      spin = 2)
+  myhf = mol.RHF().run()
+  ncas, nelecas = (6,8)
+  mycas = myhf.CASCI(ncas, nelecas).run()
+
+
+CASSCF
+""""""
+.. code-block:: python
+
+  import pyscf
+  mol = pyscf.M(
+      atom = 'O 0 0 0; O 0 0 1.2',
+      basis = 'ccpvdz',
+      spin = 2)
+  myhf = mol.RHF().run()
+  ncas, nelecas = (6,8)
+  mycas = myhf.CASSCF(ncas, nelecas).run()
+
+Like many other modules in PySCF, :mod:`mcscf` works with density-fitting (:numref:`user_df`) and x2c (:numref:`user_x2c`).
+It can also be used in its unrestricted formulation, please see :source:`examples/mcscf/60-uhf_based_ucasscf.py` for an example.
+An important feature of :mod:`mcscf` is that it can interface with external CI solver such as DMRG, FCIQMC, or selected CI methods, see the external projects for more details.
 
 
 
- The third argument for CASCI/CASSCF is the size of CAS space; the
-fourth argument is the number of electrons.  By default, the CAS
-solver determines the alpha-electron number and beta-electron number
-based on the attribute :attr:`Mole.spin`.  In the above example, the
-number of alpha electrons is equal to the number of beta electrons,
-since the ``mol`` object is initialized with ``spin=0``.  The spin
-multiplicity of the CASSCF/CASCI solver can be changed by the fourth
-argument::
+Picking an Active Space
+-----------------------
+In general, selecting an active space can be cumbersome and PySCF offers severals ways to facilitate this process.
+There are four strategies and all require that you specify the number of electrons and orbitals in the active space.
 
-  >>> mc = mcscf.CASSCF(m, 4, (4,2))
-  >>> print('E(CASSCF) = %.9g' % mc.kernel()[0])
-  E(CASSCF) = -149.609461
-  >>> print('S^2 = %.7f, 2S+1 = %.7f' % mcscf.spin_square(mc))
-  S^2 = 2.0000000, 2S+1 = 3.0000000
+.. warning::
+  We always advise users to visualize their chosen active orbitals before starting large/expensive calculations.
+  This involves dumping the MO coefficients to a ``molden`` file (see example :source:`examples/tools/02-molden.py`) and visualizing with your chosen program.
+  While there are many great softwares available to visualize orbitals, `JMol <http://jmol.sourceforge.net/>`_ is one of the easiest to use and is recommended for less experienced users.
 
-The two integers in the tuple represent the number of alpha and beta electrons.
-Although it is a triplet state, the solution might not be correct since the
-CASSCF is based on the incorrect singlet HF ground state.  Starting from the
-ROHF ground state, we have::
 
-  >>> mc = mcscf.CASSCF(rhf3, 4, 6)
-  >>> print('E(CASSCF) = %.9g' % mc.kernel()[0])
-  E(CASSCF) = -149.646746
+1) (Default) Specifying no additional information.
+  This is the most minimal strategy for selecting an active space and chooses orbitals (and electrons) around the fermi-level that match the number of orbitals and electrons specified by the user.
+  In most circumstances, this is not an ideal strategy and will lead to poor convergence or none at all.
+  For example:
+.. code-block:: python
 
-The energy is lower than the RHF initial guess.
-.. We can also use the UHF ground
-.. state to start a CASSCF calculation::
-.. 
-..   >>> mc = mcscf.CASSCF(uhf3, 4, 6)
-..   >>> print('E(CASSCF) = %.9g' % mc.kernel()[0])
-..   E(CASSCF) = -149.661324
-..   >>> print('S^2 = %.7f, 2S+1 = %.7f' % mcscf.spin_square(mc))
-..   S^2 = 3.9713105, 2S+1 = 4.1091656
-.. 
-.. Woo, the total energy is even lower.  But the spin is contaminated.
+  ncas, nelecas = (6,8)
+  mycas = myhf.CASSCF(ncas, nelecas)
+
+
+2) Specifying the molecular orbital (MO) index of the active space orbitals you want. 
+  The user can "manually" selects the MO orbital indices (in a 1-based indexing scheme) and passes them to the ``sort_mo`` function.
+  See :source:`examples/mcscf/10-define_cas_space.py` for more details.
+
+.. code-block:: python
+
+  mycas = mcscf.CASSCF(myhf, 4, 4)
+  # Note sort_mo by default take the 1-based orbital indices.
+  mo = mycas.sort_mo([5,6,8,9])
+  mycas.kernel(mo)
+
+
+3) Specifying the number of orbitals in each symmetry group. 
+This strategy can occasionally be helpful when the initial guess orbitals are not easily identifiable.
+
+.. code-block:: python
+
+  mycas = mcscf.CASSCF(mf, 12, 12)
+  ncore = {'A1g':5, 'A1u':5}
+  ncas = {'A1g':2, 'A1u':2,'E1ux':1, 'E1uy':1, 'E1gx':1, 'E1gy':1,
+              'E2ux':1, 'E2uy':1, 'E2gx':1, 'E2gy':1}
+  mo = mcscf.sort_mo_by_irrep(mycas, mf.mo_coeff, ncas, ncore)
+  mycas.kernel(mo)
+
+A similar approach where we specify the electron occupations by irreducible representation is also possible by setting ``mycas.fcisolver.irrep_nelec``.
+
+.. code-block:: python
+
+  mycas = mcscf.CASSCF(myhf, 8, 8)
+  mycas.fcisolver.irrep_nelec = {"A1g": (2, 1), "A1u": (1, 1), "E1ux": (1, 1), "E1uy": (1, 0)}
+
+4) Use automated strategies (``avas`` and ``dmet_cas``) to pick an active space based on AO orbitals you're targeting.
+For more details, see :source:`examples/mcscf/43-avas.py` and :source:`examples/mcscf/43-dmet_cas.py`.
+
+.. code-block:: python
+
+  from pyscf.mcscf import avas
+  ao_labels = ['Fe 3d', 'Fe 4d', 'C 2pz']
+  ncas, nelecas, orbs = avas.avas(mf, ao_labels)
+  mycas = mcscf.CASSCF(mf, ncas, nelecas)
+
+  
+
+.. code-block:: python
+
+  from pyscf.mcscf import dmet_cas
+  ao_labels = ['Fe 3d', 'Fe 4d', 'C 2pz']
+  ncas, nelecas, mo = dmet_cas.guess_cas(mf, mf.make_rdm1(), ao_labels)
+  mycas = mcscf.CASSCF(mf, ncas, nelecas)
+  mycas.kernel(mo)
+
+
+Frozen Core MCSCF
+-----------------
+
+To reduce to computational expense of CASSCF calculations, users can "freeze" orbitals thereby excluding them from optimization.
+
+Users can specify a number to free the N lowest orbitals:
+
+.. code-block:: python
+
+  mycas = mcscf.CASSCF(myhf, 6, 8)
+  mycas.frozen = 2
+  mycas.kernel()
+
+
+Users can also specify a list of orbital indices (0-based).
+These may be occupied, virtual, or active orbitals.
+
+.. code-block:: python
+  mycas = mcscf.CASSCF(myhf, 6, 8)
+  mycas.frozen = [0,1,26,27]
+  mycas.kernel()
+
+See :source:`examples/mcscf/19-frozen_core.py` for a complete example.
+
+
+State-Averaged Calculations
+---------------------------
+
+When dealing with states that are close in energy, it can be helpful to perform state average calculations where the multireference orbitals are optimized for multiple states.
+The ``state_average_`` function (note the hanging underscore) is a member function of ``CASCI``/``CASSCF`` objects and takes the weights of the states as input.
+The weights can be any normalized and non-negative array of values.
+
+.. code-block:: python
+
+  n_states = 5
+  weights = np.ones(n_states)/n_states
+  mycas = mcscf.CASSCF(mf, 4, 4).state_average_(weights)
+
+See :source:`examples/mcscf/15-state_average.py` for a complete example.
+
+
+By default, only a single spin and/or point group symmetry is targeted, but it is possible to target a mixture of both:
+
+.. code-block:: python
+
+  weights = [.5, .5]
+  solver1 = fci.direct_spin1_symm.FCI(mol)
+  solver1.wfnsym= 'A1'
+  solver1.spin = 0
+  solver2 = fci.direct_spin1_symm.FCI(mol)
+  solver2.wfnsym= 'A2'
+  solver2.spin = 2
+
+  mycas = mcscf.CASSCF(mf, 4, 4)
+  mcscf.state_average_mix_(mycas, [solver1, solver2], weights)
+  mycas.kernel()
+
+See :source:`examples/mcscf/41-state_average.py` for a complete example.
+
+
+Job Control
+-----------
+
+Optimization Settings
+"""""""""""""""""""""
+
+For CASSCF calculations, users may want to modify several of the convergence tolerances such as the energy tolerance (``conv_tol``), the orbital gradient tolerance (``conv_tol_grad``), and the maximum number of MCSCF iteration (``max_cycle_macro``).
+
+.. code-block:: python
+
+  mycas = mcscf.CASSCF(mf, 6, 6)
+  mycas.conv_tol = 1e-12
+  mycas.conv_tol_grad = 1e-6
+  mycas.max_cycle_macro = 25
+  mycas.kernel()
+
+
+Initial Guess
+"""""""""""""
+
+Initial guess orbitals for the CASSCF calculation may be passed to the ``kernel`` member function of an MCSCF object.
+
+.. code-block:: python
+
+  mycas = mcscf.CASSCF(myhf, 8, 8)
+  mycas.kernel(my_custom_mos)
+
+
+CI coefficient from previous or related calculations can also be passed as an initial guess to expedite a calculation:
+
+.. code-block:: python
+  mycas = mcscf.CASSCF(myhf, 8, 8)
+  mycas.kernel(my_custom_mos, my_custom_ci)
+
+Examples:
+
+* :source:`examples/mcscf/14-project_init_guess.py`
+* :source:`examples/mcscf/31-cr2_scan/cr2-scan.py`
+* :source:`examples/mcscf/34-init_guess_localization.py`
+* :source:`examples/mcscf/43-avas.py`
+* :source:`examples/mcscf/43-dmet_cas.py`
+
+
+Restarting
+""""""""""
+
+.. warning::
+  When running large calculations, it's always recommended that you specify a checkpoint file for your calculation.
+
+.. code-block:: python
+
+  mycas.chkfile = "casscf.chk"
+
+Much like :mod:`scf`, if a job is interrupted, users can restart the MCSCF calculations using checkpoint files from a crashed calculation.
+
+.. code-block:: python
+
+  from pyscf.lib import chkfile
+  old_chk_file = "old_casscf.chk"
+  mycas = mcscf.CASSCF(scf.RHF(mol), 6, 6)
+  mycas.chkfile = "restarted_casscf.chk"
+  mo = chkfile.load(old_chk_file, 'mcscf/mo_coeff')
+  mycas.kernel(mo)
+
+
+See :source:`examples/mcscf/13-restart.py` for a complete example.
+
+Observables and Properties
+--------------------------
+
+Wave Function Analysis
+""""""""""""""""""""""
+
+The ``analyze`` member functions of MCSCF objects prints many useful properties to ``stdout`` when the verbosity is >=4.
+
+1) Natural orbital occupancies
+2) Natural orbital AO expansions
+3) Overlap between canonical MCSCF orbitals and the initial guess orbitals.
+4) Analysis of the CI coefficients, i.e. the leading configurations and their weights
+5) AO populations
+6) Atomic populations
+7) AO spin densities (if applicable)
+8) Atomic spin densities (if applicable)
+
+.. code-block:: python
+  mycas = myhf.CASCI(6, 8).run()
+  mycas.verbose = 4
+  mycas.analyze()
+
+
+Natural Orbitals
+""""""""""""""""
+
+Users can request that the converged MCSCF orbitals be transformed with the member attribute ``natorb``
+
+.. warning::
+  When ``mycas.natorb`` is set, the natural orbitals may NOT be sorted by the active space occupancy.
+
+.. code-block:: python
+
+  mycas = mcscf.CASSCF(myhf, 6, 8)
+  mycas.natorb = True
+  mycas.kernel()
+
+
+
+References
+----------
+
+.. bibliography:: ref_mcscf.bib
+   :style: unsrt

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -126,7 +126,7 @@ This strategy is often helpful when the system has a high degree of symmetry, or
   mo = mcscf.sort_mo_by_irrep(mycas, mf.mo_coeff, ncas, ncore)
   mycas.kernel(mo)
 
-A similar approach where we specify the electron occupations by irreducible representation is also possible by setting ``mycas.fcisolver.irrep_nelec``.
+A similar approach where we specify the number of electrons in each irreducible representation is also possible by setting ``mycas.fcisolver.irrep_nelec``.
 
 .. code-block:: python
 

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -101,7 +101,7 @@ Below is a list of several general strategies one could employ to pick active sp
   Hartree-Fock orbitals are often poor for systems with significant static correlation.
   In such cases, orbitals from density functional calculations often yield better starting points for CAS calculations.
 
-2) Specifying the molecular orbital (MO) index of the active space orbitals you want. 
+ 2) Specifying the active space orbitals as a list of molecular orbital (MO) indices. 
   This is often useful after selecting (and typically visualizing) localized orbitals.
   The user can "manually" select the MO orbital indices (in a 1-based indexing scheme) and pass them to the ``sort_mo`` function.
   See :source:`examples/mcscf/10-define_cas_space.py` and :source:`examples/mcscf/34-init_guess_localization.py` for more details.

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -9,7 +9,7 @@ Multi-configuration self-consistent field (MCSCF)
 Introduction
 ------------
 
-Multiconfigurational self-consistent field (MCSCF) methods extend Hartree-Fock (HF) theory by describing the wave function as a linear combination of determinants. 
+Multiconfigurational self-consistent field (MCSCF) methods go beyond the single-determinant Hartree-Fock (HF) method by allowing the wave function to become a linear combination of multiple determinants.
 While there are a large variety of MCSCF methods, PySCF focuses on the complete active space (CAS) family of methods.
 Unlike full configuration interaction (FCI), described in :numref:`theory_ci`, CAS methods perform the FCI procedure on a subset of the molecular orbitals, referred to as the "active space." 
 These methods are crucial for systems that exhibit strong electron correlation, such as transition metal complexes.

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -33,6 +33,7 @@ CASCI
       basis = 'ccpvdz',
       spin = 2)
   myhf = mol.RHF().run()
+  # Use MP2 natural orbitals to define the active space for the single-point CAS-CI calculation
   mymp = mp.UMP2(myhf).run()
 
   noons, natorbs = mcscf.addons.make_natural_orbitals(mymp)

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -193,7 +193,7 @@ State-Averaged Calculations
 When your system has states that are close-by in energy, their ordering may change during the orbital optimization and result in non-convergence of the CASSCF optimization.
 In such cases it is often helpful to optimize the orbitals for a state average.
 The ``state_average_`` function (note the hanging underscore) is a member function of ``CASCI``/``CASSCF`` objects and takes the weights of the states as input.
-The weights can be any normalized and non-negative array of values, but typically they are all the same.
+The weights can be any normalized and non-negative array of values, but equal weights are typically used.
 See Section 12.7.2 in Ref. :cite:`Helgaker2013` for more details.
 
 .. code-block:: python

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -158,7 +158,7 @@ For more details, see :source:`examples/mcscf/43-avas.py` and :source:`examples/
   mycas.kernel(mo)
 
 
- Frozen-orbital MCSCF
+Frozen-orbital MCSCF
 -----------------
 
 To reduce to computational expense of CASSCF calculations, users can "freeze" orbitals thereby excluding them from optimization.

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -16,9 +16,10 @@ The use of MCSCF methods is crucial for reliable modeling of systems that exhibi
 For a detailed discussion of MCSCF methods, we direct the reader to References :cite:`Helgaker2013` and :cite:`esqc`.
 
 The MCSCF module has two main flavors: CASCI and CASSCF. 
-CASCI expands the wave function as a linear combination of slater determinants and variationally solves for the coefficients of this expansion.
-CASSCF calculations optimize the orbitals for the set of determinants and the coefficients of their expansion.
-This means performing multiple (and possibly many) CASCI step.
+In CASCI, the wave function is written as a linear combination of Slater determinants, and the expansion coefficients are solved in a variational procedure.
+The orbitals are fixed in a CASCI calculation.
+In contrast, in a CASSCF calculation, the orbitals are relaxed to minimize the resulting CASCI energy.
+This means performing multiple CASCI steps followed by updates to the molecular orbitals, in analogy to Hartree-Fock calculations which also relies on iterative algorithms to minimize the HF energy with respect to the orbitals.
 
 Minimal examples for each type of calculations are shown below.
 

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -158,7 +158,7 @@ For more details, see :source:`examples/mcscf/43-avas.py` and :source:`examples/
   mycas.kernel(mo)
 
 
-Frozen Core MCSCF
+ Frozen-orbital MCSCF
 -----------------
 
 To reduce to computational expense of CASSCF calculations, users can "freeze" orbitals thereby excluding them from optimization.

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -115,7 +115,7 @@ Below is a list of several general strategies one could employ to pick active sp
 
 
 3) Specifying the number of orbitals in each symmetry group. 
-This strategy can occasionally be helpful when the initial guess orbitals are not easily identifiable.
+This strategy is often helpful when the system has a high degree of symmetry, or when there is no physically evident best choise for the active orbitals.
 
 .. code-block:: python
 

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -131,7 +131,7 @@ Frozen Core MCSCF
 
 To reduce to computational expense of CASSCF calculations, users can "freeze" orbitals thereby excluding them from optimization.
 
-Users can specify a number to free the N lowest orbitals:
+Users can specify the number of lowest orbitals to freeze:
 
 .. code-block:: python
 

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -75,7 +75,9 @@ There are several strategies and they all contain two main components:
   warning::
   The total set orbitals (core, active, and virtual) used in active space methods can be specified or selected in a variety of ways, giving users substantial flexibility for CAS-type calculations.
   But users should note, "with great power comes great responsibility."
-  Active space calculations are notoriously difficult and just because a calculation completes without error does not guarantee that the results will be chemically/physically meaningful so we urge users to select their active space orbitals with thought and care.
+  Active space calculations are notoriously difficult and just because a calculation completes without error does not guarantee that the results will be chemically/physically meaningful.
+  We urge users to select their active space orbitals with thought and care.
+  You should always try out several choices for the active space!
 
 .. note::
   We always advise users to visualize their chosen active orbitals before starting large/expensive calculations.

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -97,6 +97,9 @@ Below is a list of several general strategies one could employ to pick active sp
   ncas, nelecas = (6,8)
   mycas = myhf.CASSCF(ncas, nelecas)
 
+.. note::
+  Hartree-Fock orbitals are often poor for systems with significant static correlation.
+  In such cases, orbitals from density functional calculations often yield better starting points for CAS calculations.
 
 2) Specifying the molecular orbital (MO) index of the active space orbitals you want. 
   This is often useful after selecting (and typically visualizing) localized orbitals.

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -132,7 +132,11 @@ A similar approach where we specify the number of electrons in each irreducible 
 
   mycas = mcscf.CASSCF(myhf, 8, 8)
   mycas.fcisolver.irrep_nelec = {"A1g": (2, 1), "A1u": (1, 1), "E1ux": (1, 1), "E1uy": (1, 0)}
-
+.. note::
+  This strategy is often combined with calculations at a lower level of theory.
+  For instance, MP2 or CISD natural orbitals and their occupation numbers can be used determine the suitable active space in each symmetry block.
+  Natural orbitals with occupations close to 2 are strongly occupied, and can be frozen in the CAS calculation.
+  Natural orbitals with small occupation numbers can likewise be omitted from the active space.
 4) Use automated strategies (``avas`` and ``dmet_cas``) to pick an active space based on AO orbitals you're targeting.
 For more details, see :source:`examples/mcscf/43-avas.py` and :source:`examples/mcscf/43-dmet_cas.py`.
 

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -183,6 +183,9 @@ These may be occupied, virtual, or active orbitals.
 
 See :source:`examples/mcscf/19-frozen_core.py` for a complete example.
 
+.. note::
+  The `frozen` keyword of the CASSCF optimizer should not be confused with the `frozen` keyword of the FCI solver, which controls the number of orbitals that are constrained to be doubly occupied.
+
 
 State-Averaged Calculations
 ---------------------------

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -10,8 +10,8 @@ Introduction
 ------------
 
 Multiconfigurational self-consistent field (MCSCF) methods go beyond the single-determinant Hartree-Fock (HF) method by allowing the wave function to become a linear combination of multiple determinants.
-While there are a large variety of MCSCF methods, PySCF focuses on the complete active space (CAS) family of methods.
-Unlike full configuration interaction (FCI), described in :numref:`theory_ci`, CAS methods perform the FCI procedure on a subset of the molecular orbitals, referred to as the "active space." 
+While the configurations i.e. determinants can in principle be chosen in an arbitrary number of ways, PySCF focuses on the complete active space (CAS) family of methods, where the set of electron configurations is defined in terms of a given set of active orbitals, also known as the "active space".
+The CAS method generates all possible electron configurations that can be formed from the set of the active orbitals, and is therefore equivalent to an FCI procedure on a subset of the molecular orbitals; please see :numref:`theory_ci` for a discussion on the FCI method.
 These methods are crucial for systems that exhibit strong electron correlation, such as transition metal complexes.
 For a detailed discussion of MCSCF methods, we direct the reader to References :cite:`Helgaker2013` and :cite:`esqc`.
 

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -53,7 +53,8 @@ CASSCF
       spin = 2)
   myhf = mol.RHF().run()
   ncas, nelecas = (6,(5,3))
-  mycas = myhf.CASSCF(ncas, nelecas).run()
+   # We can also run CAS calculations starting from the Hartree-Fock orbitals.
+   mycas = myhf.CASSCF(ncas, nelecas).run()
 
 Like many other modules in PySCF, :mod:`mcscf` works with density-fitting (:numref:`user_df`) and x2c (:numref:`user_x2c`).
 It can also be used in its unrestricted formulation, please see :source:`examples/mcscf/60-uhf_based_ucasscf.py` for an example.

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -190,7 +190,8 @@ See :source:`examples/mcscf/19-frozen_core.py` for a complete example.
 State-Averaged Calculations
 ---------------------------
 
-When dealing with states that are close in energy, it can be helpful to perform state average calculations where the orbitals are optimized for multiple states.
+When your system has states that are close-by in energy, their ordering may change during the orbital optimization and result in non-convergence of the CASSCF optimization.
+In such cases it is often helpful to optimize the orbitals for a state average.
 The ``state_average_`` function (note the hanging underscore) is a member function of ``CASCI``/``CASSCF`` objects and takes the weights of the states as input.
 The weights can be any normalized and non-negative array of values, but typically they are all the same.
 See Section 12.7.2 in Ref. :cite:`Helgaker2013` for more details.

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -12,7 +12,7 @@ Introduction
 Multiconfigurational self-consistent field (MCSCF) methods go beyond the single-determinant Hartree-Fock (HF) method by allowing the wave function to become a linear combination of multiple determinants.
 While the configurations i.e. determinants can in principle be chosen in an arbitrary number of ways, PySCF focuses on the complete active space (CAS) family of methods, where the set of electron configurations is defined in terms of a given set of active orbitals, also known as the "active space".
 The CAS method generates all possible electron configurations that can be formed from the set of the active orbitals, and is therefore equivalent to an FCI procedure on a subset of the molecular orbitals; please see :numref:`theory_ci` for a discussion on the FCI method.
-These methods are crucial for systems that exhibit strong electron correlation, such as transition metal complexes.
+The use of MCSCF methods is crucial for reliable modeling of systems that exhibit nearly degenerate orbitals i.e. static correlation, such as transition metal complexes.
 For a detailed discussion of MCSCF methods, we direct the reader to References :cite:`Helgaker2013` and :cite:`esqc`.
 
 The MCSCF module has two main flavors: CASCI and CASSCF. 

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -97,7 +97,7 @@ Below is a list of several general strategies one could employ to pick active sp
   This is often useful after selecting (and typically visualizing) localized orbitals.
   The user can "manually" select the MO orbital indices (in a 1-based indexing scheme) and pass them to the ``sort_mo`` function.
   See :source:`examples/mcscf/10-define_cas_space.py` and :source:`examples/mcscf/34-init_guess_localization.py` for more details.
-  
+
 .. code-block:: python
 
   mycas = mcscf.CASSCF(myhf, 4, 4)
@@ -295,6 +295,7 @@ The ``analyze`` member functions of MCSCF objects prints many useful properties 
 8) Atomic spin densities (if applicable)
 
 .. code-block:: python
+
   mycas = myhf.CASCI(6, 8).run()
   mycas.verbose = 4
   mycas.analyze()

--- a/source/user/ref_mcscf.bib
+++ b/source/user/ref_mcscf.bib
@@ -1,0 +1,11 @@
+@book{Helgaker2013,
+  author    = {Helgaker, Trygve and Jorgensen, Poul and Olsen, Jeppe},
+  isbn      = {9781118531471},
+  publisher = {Wiley},
+  title     = {{Molecular Electronic-Structure Theory}},
+  year      = {2013}
+}
+@misc{esqc,
+  title = {ESQC Lectures 2019},
+  url   = {http://www.esqc.org/?page=lectures}
+}

--- a/source/user/scf.rst
+++ b/source/user/scf.rst
@@ -425,6 +425,8 @@ orthonormalization technique
 shown to work reliably even in the presence of such truly pathological
 linear dependencies.
   
+.. _user_x2c: 
+
 Scalar relativistic correction
 ==============================
 

--- a/source/user/x2c.rst
+++ b/source/user/x2c.rst
@@ -1,3 +1,4 @@
+.. _user_x2c:
 
 Relativistic calculations
 *************************

--- a/source/user/x2c.rst
+++ b/source/user/x2c.rst
@@ -1,5 +1,3 @@
-.. _user_x2c:
-
 Relativistic calculations
 *************************
 


### PR DESCRIPTION
# Summary

I updated and filled out the user guide section for the MCSCF module and added a `.bib` file.

## Potential Conflicts with Other PRs

1) I changed the name of the mcscf user guide page to `user_mcscf` (from `theory_mcscf`).
2) I added a name (`user_x2c`) to `user/x2c.rst` so I could reference it from `user/mcscf.rst`.

## Going forward
Let me know if you find any typos or have other suggestions!