### PR TITLE
Deal with some sphinx warnings

### DIFF
--- a/source/contributing.rst
+++ b/source/contributing.rst
@@ -29,28 +29,28 @@ How to make an extension
 1. Download the template (https://github.com/pyscf/extension-template), run the
    script in the extension template::
 
-  $ curl https://github.com/pyscf/extension-template/pyscf-extension-template-0.1.0.tar.gz | tar xvzf -
-  $ mv extension-template new-project
-  $ cd new-project
-  $ make new-project
+    $ curl https://github.com/pyscf/extension-template/pyscf-extension-template-0.1.0.tar.gz | tar xvzf -
+    $ mv extension-template new-project
+    $ cd new-project
+    $ make new-project
 
 2. Check whether files like `README.md`, `setup.py`, `__init__.py` are correctly updated.
 
 3. In the new project folder, initialize git repo::
 
-  $ git init 
-  $ git add .
-  $ git commit -m "An example of new extension package"
+    $ git init
+    $ git add .
+    $ git commit -m "An example of new extension package"
 
 4. If your program needs to compile C/C++ code, you can edit the setup.py to
    include your code files. For example::
 
-  SO_EXTENSIONS = {
-    'pyscf.new_feature.new_feature': ['pyscf/new_feature/new_feature.cc']
-  }
+    SO_EXTENSIONS = {
+      'pyscf.new_feature.new_feature': ['pyscf/new_feature/new_feature.cc']
+    }
 
+5. Release the extension project on https://github.com/pyscf.
 
-4. Release the extension project on https://github.com/pyscf.
    * Open an issue on https://github.com/pyscf/pyscf about the new project.
    * When the issue is approved, a repo will be created under https://github.com/pyscf/new-project.
      You can run the commands below to sync your local repo to the remote one::

--- a/source/develop/eph_developer.rst
+++ b/source/develop/eph_developer.rst
@@ -16,7 +16,7 @@ All EPH classes in :mod:`pyscf.eph` are implemented as derived class of the base
 :class:`pyscf.eph.uhf.EPH`           UHF
 :class:`pyscf.eph.rks.EPH`           RKS
 :class:`pyscf.eph.uks.EPH`           UKS
-=================================== ======
+=================================== =====
 
 The key attributes of the EPH class include
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -23,7 +23,7 @@ with the following principles:
 In addition to the core libraries, PySCF supports a rich
 ecosystem of plugins and external modules that, for example, provide
 MPI versions of some routines, additional quantum chemistry methods and analysis, interface with quantum computing toolkits *etc*.
-See :ref:`installing_plugin`.
+See :ref:`installing_extproj`.
 
 .. toctree::
    :maxdepth: 1

--- a/source/install.rst
+++ b/source/install.rst
@@ -108,6 +108,7 @@ shell::
 
 
 .. _compile_c_extensions:
+
 Compiling from source code
 ==========================
 
@@ -180,14 +181,14 @@ directory can be used to fix this problem::
 Environment variables and global configures
 ===========================================
 
------------------------ ---------------------------------------------------------
+======================= =========================================================
 Env variable            Comments
 ----------------------- ---------------------------------------------------------
 `PYSCF_MAX_MEMORY`      Maximum memory to use in MB
 `PYSCF_TMPDIR`          Directory for temporary files
 `PYSCF_CONFIG_FILE`     File where various PySCF default settings are stored
 `PYSCF_EXT_PATH`        Path for finding external extensions
------------------------ ---------------------------------------------------------
+======================= =========================================================
 
 `PYSCF_MAX_MEMORY` sets the default maximum memory in MB when creating
 `Mole` (or `Cell`) object. It corresponds to the attribute
@@ -216,6 +217,7 @@ packages. This is documented in detail in :ref:`installing_extproj`.
 
 
 .. _installing_wo_network:
+
 Installation without network
 ============================
 
@@ -270,6 +272,7 @@ that the Python interpreter can find your installation of PySCF.
 
 
 .. _installing_blas:
+
 Using optimized BLAS
 ====================
 
@@ -334,6 +337,7 @@ You can also hardcode the libraries you want to use in
 
 
 .. _installing_qcint:
+
 Using optimized integral library
 ================================
 
@@ -373,13 +377,14 @@ directory ``pyscf/lib/cmake_arch_config``.
 
 
 .. _installing_extproj:
+
 Extension modules
 =================
 
 As of PySCF-2.0, some modules have been moved from the main code trunk
 to extension projects hosted at https://github.com/pyscf.
 
-------------------- ---------------------------------------------------------
+=================== =========================================================
 Project             URL
 ------------------- ---------------------------------------------------------
 cornell_shci        https://github.com/pyscf/cornell_shci
@@ -396,7 +401,7 @@ semiempirical       https://github.com/pyscf/semiempirical
 shciscf             https://github.com/pyscf/shciscf
 zquatev             https://github.com/sunqm/zquatev
 tblis               https://github.com/pyscf/pyscf-tblis
-------------------- ---------------------------------------------------------
+=================== =========================================================
 
 Based on the technique of namespace packages specified in `PEP 420
 <https://www.python.org/dev/peps/pep-0420/>`, PySCF has developed a

--- a/source/user/agf2.rst
+++ b/source/user/agf2.rst
@@ -91,7 +91,7 @@ consistency based on the  first two self-energy spectral moments is the default
 behaviour.
 
 Photoemission spectra
-====================
+=====================
 
 The compression of the effective dynamics performed in AGF2 permits the 
 calculation of the full spectrum of charged excitations, as no additional 

--- a/source/user/pbc/df.rst
+++ b/source/user/pbc/df.rst
@@ -16,7 +16,7 @@ Like for molecular calculations, density fitting (DF) is useful to reduce the co
 
 * The mixed density fitting (:class:`MDF`) uses both PWs and GTOs as the auxiliary basis functions. :cite:`Sun17JCP`
 
-This section of the user document covers the basic usage of these DF methods in periodic calculations. The recommended choice of DF methods for different applications is also provided. See :ref:`theory_df` for the use of DF in molecular calculations.
+This section of the user document covers the basic usage of these DF methods in periodic calculations. The recommended choice of DF methods for different applications is also provided. See :ref:`user_df` for the use of DF in molecular calculations.
 
 
 Using DF in periodic calculations

--- a/source/user/pbc/gto.rst
+++ b/source/user/pbc/gto.rst
@@ -67,7 +67,7 @@ PySCF uses the crystalline Gaussian-type orbitals as the basis functions
 for solid calculations. The predefined such basis sets include 
 the valence basis sets that are optimized for the GTH pseudopotentials 
 (a whole list can be found in :source:`pyscf/pbc/gto/basis` and :source:`pyscf/pbc/gto/pseudo`).
-The input format of `basis sets`_ for the :class:`Cell` object is the same 
+The input format of :ref:`basis sets` for the :class:`Cell` object is the same
 as that for the :class:`Mole` object.
 In addition, the predefined basis sets and ECPs for molecular calculations 
 can be used in solid calculations as well


### PR DESCRIPTION
Dealt with some sphinx warnings and fixed two tables.
`basis set` reference in `user/pbc/gto.rst` still does not seem to work properly? Also, GW tries to include two examples that are not found.