### PR TITLE
Deploying Docs with CI

### DIFF
--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -1,5 +1,8 @@
 name: Build and Deploy
-on: [push]
+on:
+  push:
+    branches:
+      - master
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -11,6 +11,8 @@ jobs:
         run: |
           python -m pip install -r requirements.txt
           make html_full
+          cat _build.log
+          cat _build_err.log
           make gh_pages_setup
 
       - name: Deploy 🚀

--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -10,9 +10,7 @@ jobs:
       - name: Install and Build 🔧
         run: |
           python -m pip install -r requirements.txt
-          make html_full
-          cat _build.log
-          cat _build_err.log
+          make html_full || cat _build.log; cat _build_err.log
           make gh_pages_setup
 
       - name: Deploy 🚀

--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -18,3 +18,4 @@ jobs:
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: docs # The folder the action should deploy.
+          target-folder: docs

--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -1,0 +1,20 @@
+name: Build and Deploy
+on: [push]
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+
+      - name: Install and Build 🔧
+        run: |
+          python -m pip install -r requirements.txt
+          make html_full
+          make gh_pages_setup
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.1
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: docs # The folder the action should deploy.

--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -17,5 +17,4 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@4.1.1
         with:
           branch: gh-pages # The branch the action should deploy to.
-          folder: docs # The folder the action should deploy.
-          target-folder: docs
+          folder: . # The folder the action should deploy.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ ablog
 sphinx-material
 sphinxcontrib-bibtex
 nbsphinx
+Pygments==2.6.1


### PR DESCRIPTION
# Summary

This PR creates a single file `.github/workflows/docs_deploy.yaml` which runs after every `git push` command (to the `master` branch) to populate the `gh-pages` branch where we'll deploy the website from.

# After merging this PR
After we merge this PR we still have a one thing to do in order for GitHub pages to start serving our site. Someone with admin access needs to edit pyscf-doc settings so GitHub Pages will deploy using the `docs` directory in `gh-pages` branch (Settings->Pages->Source).

To point this to the `pyscf.org` url we may also need to do a little bit more work maybe some permission tokens or something, but I'm not sure. I haven't done this with a custom url before.