### PR TITLE
Adding MCSCF refs. Adding citation for GW refs. Hiding Modules

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -234,7 +234,7 @@ language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+exclude_patterns = ["modules/*.rst"]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/source/user/gw.rst
+++ b/source/user/gw.rst
@@ -36,7 +36,8 @@ ways, controlled by the ``freq_int`` keyword argument: by analytic continuation
 exactly (Exact, ``freq_int='exact'``).  The first two are much more affordable 
 and typically provide sufficient accuracy.  GW-AC supports spin-restricted and
 spin-unrestricted calculations; GW-CD and GW-Exact only support spin-restricted
-calculations.
+calculations. Details of the GW-AC and GW-CD implementations in PySCF can be 
+found in Ref. :cite:`Zhu2021`.
 
 Analytic continuation
 ---------------------

--- a/source/user/mcscf.rst
+++ b/source/user/mcscf.rst
@@ -13,7 +13,8 @@ Multiconfigurational self-consistent field (MCSCF) methods go beyond the single-
 While the configurations i.e. determinants can in principle be chosen in an arbitrary number of ways, PySCF focuses on the complete active space (CAS) family of methods, where the set of electron configurations is defined in terms of a given set of active orbitals, also known as the "active space".
 The CAS method generates all possible electron configurations that can be formed from the set of the active orbitals, and is therefore equivalent to an FCI procedure on a subset of the molecular orbitals; please see :ref:`theory_ci` for a discussion on the FCI method.
 The use of MCSCF methods is crucial for reliable modeling of systems that exhibit nearly degenerate orbitals i.e. static correlation, such as transition metal complexes.
-For a detailed discussion of MCSCF methods, we direct the reader to References :cite:`Helgaker2013` and :cite:`esqc`.
+For a general discussion of MCSCF methods, we direct the reader to References :cite:`Helgaker2013` and :cite:`esqc`, and for specific details about PySCF's implementation of CASSCF see :cite:`Sun2017`.
+
 
 The MCSCF module has two main flavors: CASCI and CASSCF. 
 In CASCI, the wave function is written as a linear combination of Slater determinants, and the expansion coefficients are solved in a variational procedure.
@@ -101,7 +102,7 @@ Below is a list of several general strategies one could employ to pick active sp
   Hartree-Fock orbitals are often poor for systems with significant static correlation.
   In such cases, orbitals from density functional calculations often yield better starting points for CAS calculations.
 
- 2) Specifying the active space orbitals as a list of molecular orbital (MO) indices. 
+2) Specifying the active space orbitals as a list of molecular orbital (MO) indices. 
    This is often useful combined with a visual analysis of localized orbitals (see the section on localized orbitals).
   The user can select the MO orbital indices "manually" and pass them to the ``sort_mo`` function. NB! The orbitals are numbered from 1, not 0.
   See :source:`examples/mcscf/10-define_cas_space.py` and :source:`examples/mcscf/34-init_guess_localization.py` for more details.

--- a/source/user/ref_mcscf.bib
+++ b/source/user/ref_mcscf.bib
@@ -9,3 +9,18 @@
   title = {ESQC Lectures 2019},
   url   = {http://www.esqc.org/?page=lectures}
 }
+@article{Sun2017,
+  abstract = {We present a new second order complete active space self-consistent field implementation to converge wavefunctions for both large active spaces and large atomic orbital (AO) bases. Our algorithm decouples the active space wavefunction solver from the orbital optimization in the microiterations, and thus may be easily combined with various modern active space solvers. We also introduce efficient approximate orbital gradient and Hessian updates, and step size determination. We demonstrate its capabilities by calculating the low-lying states of the Fe(II)-porphine complex with modest resources using a density matrix renormalization group solver in a CAS(22,. 27) active space and a 3000 AO basis.},
+  arxivid  = {1610.08394},
+  author   = {Sun, Qiming and Yang, Jun and Chan, Garnet Kin-lic Lic},
+  doi      = {10.1016/j.cplett.2017.03.004},
+  eprint   = {1610.08394},
+  file     = {:Users/jsmith/Library/Application Support/Mendeley Desktop/Downloaded/Sun, Yang, Chan - 2017 - A general second order complete active space self-consistent-field solver for large-scale systems.pdf:pdf;:Users/jsmith/Library/Application Support/Mendeley Desktop/Downloaded/Sun, Yang, Chan - 2017 - A general second order complete active space self-consistent-field solver for large-scale systems(2).pdf:pdf;:Users/jsmith/Library/Application Support/Mendeley Desktop/Downloaded/Sun, Yang, Chan - 2017 - A general second order complete active space self-consistent-field solver for large-scale systems(3).pdf:pdf},
+  issn     = {00092614},
+  journal  = {Chemical Physics Letters},
+  keywords = {AO-driven,DMRG-CASSCF,Fe(II)-porphine,Second order CASSCF,ao-driven,dmrg-casscf,second order casscf},
+  pages    = {291--299},
+  title    = {{A general second order complete active space self-consistent-field solver for large-scale systems}},
+  volume   = {683},
+  year     = {2017}
+}


### PR DESCRIPTION
# Summary

This PR:
1. Adds MCSCF references to Sun, Yang, and Chan in user guide.
2. Adds citation to the recently added GW reference (see #62) in the user guide.
3. Changes the `conf.py` file so it also excludes the modules files from sphinx builds (aka what #63 does).