### PR TITLE
Fixes typo in AGF2 equation

### DIFF
--- a/source/user/agf2.rst
+++ b/source/user/agf2.rst
@@ -40,9 +40,9 @@ can be written as
 .. math::
     \Sigma_{xy}(\omega)
     &= \sum_{ija} \frac{ (xi|ja) [ 2 (yi|ja) - (yj|ia) ] }
-                       { E_i + E_j - E_a } \\
+                       { \omega - (E_i + E_j - E_a) } \\
     &+ \sum_{abi} \frac{ (xa|bi) [ 2 (ya|bi) - (yb|ai) ] }
-                       { E_a + E_b - E_i }.
+                       { \omega - (E_a + E_b - E_i) }.
 
 In AGF2, the first two spectral moments of the MP2 self-energy,
 


### PR DESCRIPTION
This PR fixes a typo in an AGF2 equation: missed a couple of frequency variables.