### PR TITLE
Added documentation for the "native" DF-MP2 implementation.

### DIFF
--- a/source/user/mp.rst
+++ b/source/user/mp.rst
@@ -11,10 +11,11 @@ also :ref:`user_cc`.
 Introduction
 ============
 
-Second-order Møller–Plesset perturbation theory (MP2) :cite:`Moller1934`
-is a post-Hartree--Fock method.
-MP2 calculations can be performed with or without density fitting,
-depending on the initial SCF calculation.
+Second-order Møller–Plesset perturbation theory (MP2) :cite:`Moller1934` is a
+post-Hartree--Fock method.  MP2 calculations can be performed with or without
+density fitting, depending on the initial SCF calculation. Please make sure to
+read the section on the :ref:`native DF-MP2 implementation<DFMP2>`, which does
+not depend on the integral approximation in SCF.
 
 A simple example (see :source:`examples/mp/00-simple_mp2.py`) of running
 an MP2 calculation is
@@ -122,6 +123,101 @@ don't need to be saved in memory::
     mymp = mp.MP2(mf)
     # by default, with_t2=True 
     mymp.kernel(with_t2=False)
+
+
+.. _DFMP2:
+
+Density-fitted MP2 (DF-MP2)
+===========================
+
+Background
+----------
+
+MP2 can be combined to great benefit with the density fitting (DF) or resolution of the identity
+(RI) approximation. While the formal scaling remains :math:`O(N^5)`, the prefactor and the overall
+computational cost are reduced strongly, so that calculations can be performed on much larger
+molecules than with conventional MP2. In general, the errors in reaction energies, geometries,
+properties etc. with a suitable auxiliary set are negligible compared to the intrinsic errors of
+MP2. This implementation can calculate energies, as well as unrelaxed and relaxed one-particle
+density matrices. Analytical gradients are not available yet. RHF and UHF references are supported
+throughout.
+
+Please note that this part of the documentation does *not* describe the older ``mp.dfmp2.DFMP2``
+implementation, which is still returned by the ``density_fit()`` method of the ``mp.mp2.MP2``
+class; instead it is about the newer ``DFRMP2`` and ``DFUMP2`` classes, which need to be imported
+directly from ``mp.dfmp2_native`` or ``mp.dfump2_native`` at present.
+
+Using the DF-MP2 implementation
+--------------------------------------
+
+For technical reasons (incompatible algorithms), the "native" DF-MP2 implementation is not
+implemented as a subclass of ``mp.mp2.MP2``, but it is written as an independent class instead.
+Currently, the classes ``DFRMP2`` (for RHF references) and ``DFUMP2`` (for UHF references) need to
+be imported from the respective modules ``mp.dfmp2_native`` and ``mp.dfump2_native``::
+
+    from pyscf.mp.dfmp2_native import DFRMP2
+    from pyscf.mp.dfump2_native import DFUMP2
+
+Both modules also make the respective classes available under the alias ``DFMP2``. The file
+:source:`examples/mp/10-dfmp2.py` contains a simple example for a DF-MP2 energy calculation.
+
+There is also an older variant of DF-MP2 implemented in ``mp.dfmp2``, which does not exploit the
+advantages of density fitting fully, and may therefore have much higher memory demands for larger
+molecules. Please note that the ``density_fit()`` method of the conventional ``mp.mp2.MP2`` class
+provides an instance of the old implementation, not the new one! Currently, the "native"
+implementation can only be used by importing it from ``mp.dfmp2_native`` or ``mp.dfump2_native``
+directly as shown above.
+
+Unless specified by the user, an appropriate auxiliary basis set is determined automatically. Note
+that there exist different auxiliary basis sets for Coulomb and exchange fitting in DF-HF on the one
+hand, and for correlation fitting in MP2 or other dynamic correlation methods on the other hand.
+Anyway, the DF approximation in MP2 should not depend on the approximation taken for SCF. Arbitrary
+auxiliary sets can be specified with the ``auxbasis`` option::
+
+    DFMP2(mf, auxbasis='cc-pVTZ-RI')
+
+In RHF-DF-MP2 calculations, orbitals can be frozen by specifying an integer or a list. Frozen core
+UHF-DF-MP2 calculations are initiated by providing an integer or two lists of equal length (for the
+alpha and beta orbitals)::
+
+   DFRMP2(mf, frozen=2)
+   DFRMP2(mf, frozen=[0, 1])
+   DFUMP2(mf, frozen=2)
+   DFUMP2(mf, frozen=([0, 1], [0, 2]))
+
+DF-MP2 densities
+----------------
+
+Relaxed and unrelaxed 1-RDMs can be calculated for the RHF and UHF variants of the "native" DF-MP2
+implementation. The points below provide some advice on choosing the correct type of MP2 density.
+
+* The relaxed density should be used to calculate properties if the MP2 method is well-behaved for
+  the system in question. Properties calculated thereby correspond to the correct derivative of the
+  MP2 energy with respect to an appropriate external perturbation. This is illustrated in
+  :source:`examples/mp/11-dfmp2-density.py`, where the dipole moment of chloromethane is calculated
+  much more accurately with the relaxed density than with the unrelaxed one. To calculate the
+  relaxed density, a set of CP-SCF type equations needs to be solved in one of the steps. In
+  ill-behaved systems, for example if there is multi-reference character, the MP2 natural occupation
+  numbers can be substantially larger than two or smaller than zero.
+
+* A typical use case for the unrelaxed density is to calculate starting orbitals for a CASSCF
+  calculation, which can be used despite the system being described poorly at MP2 level otherwise.
+  In contrast to the relaxed density, the natural occupation numbers of the unrelaxed density are
+  always between two and zero. :source:`examples/mp/12-dfump2-natorbs.py` shows how to calculate
+  natural orbitals for the allyl radical, which has a significantly spin-contaminated UHF wave
+  function. On the other hand, the unrelaxed density will often give very poor results for
+  properties (such as electrostatic moments).
+
+Spin-component scaling
+----------------------
+
+Spin-component scaled (SCS-)MP2 calculations can be performed analogously to DF-MP2 calculations
+using the classes ``SCSDFRMP2`` and ``SCSDFUMP2``, which also have got aliases such as ``SCSMP2``
+inside the respective modules. The default scaling factors can be changed to arbitrary values::
+
+  from pyscf.mp.dfmp2_native import SCSMP2
+  pt = SCSMP2(mf, ps=6/5, pt=1/3)
+  pt.kernel()
 
 
 References

--- a/source/user/mp.rst
+++ b/source/user/mp.rst
@@ -11,11 +11,13 @@ also :ref:`user_cc`.
 Introduction
 ============
 
-Second-order Møller–Plesset perturbation theory (MP2) :cite:`Moller1934` is a
-post-Hartree--Fock method.  MP2 calculations can be performed with or without
-density fitting, depending on the initial SCF calculation. Please make sure to
-read the section on the :ref:`native DF-MP2 implementation<DFMP2>`, which does
-not depend on the integral approximation in SCF.
+Second-order Møller--Plesset perturbation theory (MP2) :cite:`Moller1934` is a
+post-Hartree--Fock method. MP2 calculations can be performed in PySCF with or without
+density fitting, depending on the initial SCF calculation.
+
+Note also the existence of a :ref:`native DF-MP2 implementation<DFMP2>`, which does
+not depend on the integral approximation in SCF, and which is significantly faster than the
+default implementation of MP2 with density fitting.
 
 A simple example (see :source:`examples/mp/00-simple_mp2.py`) of running
 an MP2 calculation is
@@ -133,12 +135,14 @@ Density-fitted MP2 (DF-MP2)
 Background
 ----------
 
-MP2 can be combined to great benefit with the density fitting (DF) or resolution of the identity
+MP2 can be combined to great benefit with density fitting (DF), also known as the resolution of the identity
 (RI) approximation. While the formal scaling remains :math:`O(N^5)`, the prefactor and the overall
 computational cost are reduced strongly, so that calculations can be performed on much larger
-molecules than with conventional MP2. In general, the errors in reaction energies, geometries,
-properties etc. with a suitable auxiliary set are negligible compared to the intrinsic errors of
-MP2. This implementation can calculate energies, as well as unrelaxed and relaxed one-particle
+molecules than with conventional MP2. Provided that a suitable auxiliary basis set is used,
+the resulting DF/RI errors in reaction energies, geometries, properties etc. are negligible
+compared to the intrinsic errors of MP2. 
+
+This implementation can calculate energies, as well as unrelaxed and relaxed one-particle
 density matrices. Analytical gradients are not available yet. RHF and UHF references are supported
 throughout.
 
@@ -171,13 +175,13 @@ directly as shown above.
 Unless specified by the user, an appropriate auxiliary basis set is determined automatically. Note
 that there exist different auxiliary basis sets for Coulomb and exchange fitting in DF-HF on the one
 hand, and for correlation fitting in MP2 or other dynamic correlation methods on the other hand.
-Anyway, the DF approximation in MP2 should not depend on the approximation taken for SCF. Arbitrary
+The DF approximation in MP2 does not depend on the approximation taken for SCF. Arbitrary
 auxiliary sets can be specified with the ``auxbasis`` option::
 
     DFMP2(mf, auxbasis='cc-pVTZ-RI')
 
-In RHF-DF-MP2 calculations, orbitals can be frozen by specifying an integer or a list. Frozen core
-UHF-DF-MP2 calculations are initiated by providing an integer or two lists of equal length (for the
+In RHF-DF-MP2 calculations, orbitals can be frozen by specifying either an integer, or a list. Frozen core
+UHF-DF-MP2 calculations are initiated by providing either an integer, or two lists of equal length (for the
 alpha and beta orbitals)::
 
    DFRMP2(mf, frozen=2)


### PR DESCRIPTION
This is documentation for the new DF-MP2 code from pull request https://github.com/pyscf/pyscf/pull/963.
Please do not merge this without the pull request to the main pyscf code, otherwise this documentation will describe a non-existing feature.