### PR TITLE
Update info for the DMRG solver

### DIFF
--- a/examples/dmrg/01-dmrg_casscf_with_stackblock.py
+++ b/examples/dmrg/01-dmrg_casscf_with_stackblock.py
@@ -15,7 +15,7 @@ rest keywords are all compatible to the old Block program.
 The new block2 code (https://github.com/block-hczhai/block2-preview)
 can be more efficient than Block-1.5 (stackblock) for max bond dim < 2000,
 and for larger bond dimension they provide similar efficiency.
-The DMRGSCF interface for block2 and stackblock are the same.
+The DMRGSCF interface for block2 and stackblock is the same.
 '''
 
 from pyscf import lib

--- a/examples/dmrg/01-dmrg_casscf_with_stackblock.py
+++ b/examples/dmrg/01-dmrg_casscf_with_stackblock.py
@@ -11,6 +11,11 @@ This example shows how to input new defined keywords for stackblock program.
 
 Block-1.5 (stackblock) defines two new keywords memory and num_thrds.  The
 rest keywords are all compatible to the old Block program.
+
+The new block2 code (https://github.com/block-hczhai/block2-preview)
+can be more efficient than Block-1.5 (stackblock) for max bond dim < 2000,
+and for larger bond dimension they provide similar efficiency.
+The DMRGSCF interface for block2 and stackblock are the same.
 '''
 
 from pyscf import lib

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ sphinx-material
 sphinxcontrib-bibtex==1.0.0
 nbsphinx
 Pygments==2.7.4
+# MarkupSafe 2.1.1 breaks Jinja2 2.10.1
+MarkupSafe==2.0.1

--- a/source/install.rst
+++ b/source/install.rst
@@ -496,14 +496,19 @@ DMRG solvers
 
 Density matrix renormalization group (DMRG) theory is a powerful
 method for solving ab initio quantum chemistry problems. PySCF can be
-used with two implementations of DMRG: Block
-(https://sanshar.github.io/Block) and CheMPS2
-(http://sebwouters.github.io/CheMPS2/index.html).  `Installing Block
-<https://sanshar.github.io/Block/build.html>`_ requires a C++11
+used with three implementations of DMRG: Block
+(https://sanshar.github.io/Block), block2
+(https://block2.readthedocs.io/en/latest), and CheMPS2
+(http://sebwouters.github.io/CheMPS2/index.html).
+
+`Installing Block <https://sanshar.github.io/Block/build.html>`_ requires a C++11
 compiler.  If C++11 is not supported by your compiler, you can
-register and download the precompiled Block binary from
-https://sanshar.github.io/Block/build.html.  Before using Block or
-CheMPS2, you need create a configuration file
+download the precompiled Block binary from https://sanshar.github.io/Block/build.html.
+
+``block2`` can be easily installed via ``pip install block2`` or ``pip install block2-mpi``,
+or `building from source <https://block2.readthedocs.io/en/latest/user/installation.html>`_.
+
+Before using Block or CheMPS2, you need create a configuration file
 ``pyscf/dmrgscf/settings.py`` (as shown by settings.py.example) to
 store the path where the DMRG solver was installed.
 

--- a/source/quickstart.rst
+++ b/source/quickstart.rst
@@ -331,7 +331,7 @@ Finally, additional dynamic correlation may be added by means of second-order pe
 External Approximate Full Configuration Interaction Solvers
 -----------------------------------------------------------
 
-Besides the exact solvers discussed :ref:`earlier <FCI>`, PySCF has interfaces to efficient approximate solvers. For instance, the `StackBlock <https://github.com/sanshar/StackBlock>`_ code can be used as a DMRG solver to perform parallel DMRGSCF calculations across several processes (cf. `dmrg/01-dmrg_casscf_with_stackblock.py <https://github.com/pyscf/pyscf/blob/master/examples/dmrg/01-dmrg_casscf_with_stackblock.py>`_):
+Besides the exact solvers discussed :ref:`earlier <FCI>`, PySCF has interfaces to efficient approximate solvers. For instance, the `StackBlock <https://github.com/sanshar/StackBlock>`_ or `block2 <https://github.com/block-hczhai/block2-preview>`_ code can be used as a DMRG solver to perform parallel DMRGSCF calculations across several processes (cf. `dmrg/01-dmrg_casscf_with_stackblock.py <https://github.com/pyscf/dmrgscf/blob/master/examples/01-dmrg_casscf_with_stackblock.py>`_):
 
   >>> from pyscf import dmrgscf
   >>> import os


### PR DESCRIPTION
* Added docs for block2 DMRG in Install and QuickStart
* Fixed the broken link to ``dmrg/01-dmrg_casscf_with_stackblock.py``
* Fixed the github action failure due to the recent updates in ``MarkupSafe 2.1.1`` (required by ``Jinja2``)