### PR TITLE
Correction in user/gto.rst

### DIFF
--- a/source/user/gto.rst
+++ b/source/user/gto.rst
@@ -509,7 +509,7 @@ function by assigning the number of alpha electrons and beta electrons
 Spin and charge
 ---------------
 
-Charge and spin can be assigned to :class:`Mole` object::
+Charge and spin (the number of unpaired electrons, same to the Molpro input parameter "spin") can be assigned to :class:`Mole` object::
 
   mol.charge = 1
   mol.spin = 1

--- a/source/user/gto.rst
+++ b/source/user/gto.rst
@@ -509,7 +509,7 @@ function by assigning the number of alpha electrons and beta electrons
 Spin and charge
 ---------------
 
-Charge and spin multiplicity can be assigned to :class:`Mole` object::
+Charge and spin can be assigned to :class:`Mole` object::
 
   mol.charge = 1
   mol.spin = 1


### PR DESCRIPTION
As a first time user of PySCF, but a long-time user of Molpro, CFOUR, MRCC, OpenMolcas, etc.,  I read the documentation and surprisingly got this part wrong.

When I saw the phrase spin "multiplicity", I set spin=2 for the H atom, and got an error.  The "Note" that tells us that `spin` really refers to the number of unpaired electrons, *not* the multiplicity,  was so far below, and in a separate box, so unfortunately it escaped me until after I got the error.

For an easier experience for first-time users, I would suggest not to mention "multiplicity" when it's not actually the multiplicity being set here.  The version that I'm requesting to merge, will be interpreted correctly by a larger percentage of users that are familiar with programs.