### PR TITLE
update conda install command

### DIFF
--- a/source/user/install.md
+++ b/source/user/install.md
@@ -116,6 +116,13 @@ systems),
 conda install -c pyscf -c conda-forge pyscf
 ```
 
+To prevent potential conflict problems, it is recommended to enable the conda-forge channel in the ``.condarc``, 
+or create an environment enabling conda-forge like
+```bash
+conda create -n pyscf-env -c conda-forge -c pyscf python=3.9 pyscf
+conda activate pyscf-env
+```
+
 <!-- 
 Extension modules are not available on the Conda cloud. They should be
 installed either with pip or through the environment variable

--- a/source/user/install.md
+++ b/source/user/install.md
@@ -113,7 +113,7 @@ If you have a [Conda](https://conda.io/docs/) (or
 package can be installed from the Conda cloud (for Linux and macOS
 systems),
 ```bash
-conda install -c pyscf pyscf
+conda install -c pyscf -c conda-forge pyscf
 ```
 
 <!-- 


### PR DESCRIPTION
Fix pyscf/pyscf#2651. 
The conda-forge channel has to be enabled in condarc or conda install command. Update the doc according to discussion in pyscf/pyscf#2270.