### PR TITLE
PySCF virtual seminar information added

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -44,6 +44,7 @@ ecosystem of :ref:`installing_extproj`.
 quickstart
 user/index
 contributor/index
+Virtual Seminars <pyscf-virtual-seminar-series/index>
 Benchmarks <benchmarks>
 About <about>
 ```

--- a/source/pyscf-virtual-seminar-series/index.md
+++ b/source/pyscf-virtual-seminar-series/index.md
@@ -1,0 +1,4 @@
+
+# PySCF Virtual Seminar Series
+
+The **PySCF Virtual Seminar Series** is a monthly forum where PySCF developers can present, share, and advertise new or ongoing implementations across the PySCF software suite. The seminar is **open to everyone**—join live via **Zoom** (link below), and if you’d like calendar invites so you don’t miss a talk, please fill out the **Google Form**. If you’re interested in presenting in a future session, you can submit the form or email me.

--- a/source/pyscf-virtual-seminar-series/index.md
+++ b/source/pyscf-virtual-seminar-series/index.md
@@ -1,19 +1,27 @@
 
 # PySCF Virtual Seminar Series
 
-The **PySCF Virtual Seminar Series** is a monthly forum where PySCF developers can present, share, and advertise new or ongoing implementations across the PySCF software suite. The seminar is **open to everyone**—join live via **Zoom** (link below), and if you’d like calendar invites so you don’t miss a talk, please fill out the **Google Form**. If you’re interested in presenting in a future session, you can submit the form or email me.
+The **PySCF Virtual Seminar Series** is a monthly forum where PySCF developers can present, share, and advertise new or ongoing implementations across the PySCF software suite. The seminar is **open to everyone**, join live via **Zoom** meeting (there won't be any recording of the talk), and if you'd like calendar invites so you don't miss a talk, please fill out the **[Google Form](https://forms.gle/Potn9vEzK4r5EBqu9)**. If you’re interested in presenting in a future session, you can submit the [form](https://forms.gle/Potn9vEzK4r5EBqu9).
 
+# Important Links
+- [Presenter submission form](https://forms.gle/K8Eu4rcdrLG1Xcxs9)
+- [Calendar Invite form](https://forms.gle/Potn9vEzK4r5EBqu9). 
 
-# **Upcoming Talk**
-- **Talk-3**
-- **Date:** **January 16th, 2026, 10:30 AM CT**
-- **Title:** **"Multi-configuration state interaction methods in PySCF"**
-- **Presenter:** **Bhavnesh Jangid, University of Chicago**
-- **[Meeting link:]()**
+# Upcoming Talk    
+**Date:** **April 17th, 2026, 10:30 AM CT**  
+**Title:** **"Perturbative Methods for Excited States and Spectroscopy"**  
+**Presenter:** **Sokolov Group, The Ohio State University**  
+**[Meeting link:](https://uchicago.zoom.us/j/95914848678?pwd=B5eX3uxDUQYc3oD32z6aB74d9Fwobc.1)**  
 
 # Entire Schedule
+
 | Talk no. | Zoom link | Presenter | Date Time | Title | Institute |
-| 5 | Zoom Link | Rui Li | Nov 21st, 2025, 10:30 AM CT | Integration of the multigrid algorithm for efficient Fock build in PySCF with GPU acceleration | Caltech |
+|---|---|---|---|---|---|
+| 9 | Zoom Link | Dr. Jincheng Yu | Jul 17th, 2026, 10:30 AM CT | Correlation-Consistent Gaussian Basis Sets for Solids | University of Maryland, College Park |
+| 8 | [Zoom Link](https://uchicago.zoom.us/j/99153958018?pwd=eolXCOQ8CQdNlFgbcPCWfOkSQQh5UB.1) | Dr. Jiachen Li | Jun 19th, 2026, 10:30 AM CT | particle-particle Random Phase Approximation in PySCF for Excited States of Molecules and Defects | Yale University |
+| 7 | [Zoom Link](https://uchicago.zoom.us/j/93078303511?pwd=dnSuzRTfo31lx9lb9DEVxbk2QjhS06.1) | Dr. Nike Dattani and Jaafar Mehrez | May 15th, 2026, 10:30 AM CT | PySCF-MRCC interface: Platinum standard electronic structure calculations with arbitrary Hamiltonians | HPQC LABS |
+| 6 | [Zoom Link](https://uchicago.zoom.us/j/95914848678?pwd=B5eX3uxDUQYc3oD32z6aB74d9Fwobc.1) | Sokolov Group | April 17th, 2026, 10:30 AM CT | Perturbative Methods for Excited States and Spectroscopy | The Ohio State University |
+| 5 | Zoom Link | Rui Li | Mar 20th, 2026, 10:30 AM CT | Integration of the multigrid algorithm for efficient Fock build in PySCF with GPU acceleration | Caltech |
 | 4 | Zoom Link | Valay Agarawal | Feb 20th, 2026, 10:30 AM CT | Vendor independent GPU acceleration of multireference calculations with PySCF | Gagliardi Group, University of Chicago |
 | 3 | Zoom Link | Bhavnesh Jangid | Jan 16th, 2026, 10:30 AM CT | Multi-configuration state interaction methods in PySCF | Gagliardi Group, University of Chicago |
 | 2 | Zoom Link | Dr. Yu Jin | Dec 19th, 2025, 10:30 AM CT | Memory-efficient high-order coupled cluster implementations in PySCF | Flatiron Institute |

--- a/source/pyscf-virtual-seminar-series/index.md
+++ b/source/pyscf-virtual-seminar-series/index.md
@@ -2,3 +2,19 @@
 # PySCF Virtual Seminar Series
 
 The **PySCF Virtual Seminar Series** is a monthly forum where PySCF developers can present, share, and advertise new or ongoing implementations across the PySCF software suite. The seminar is **open to everyone**—join live via **Zoom** (link below), and if you’d like calendar invites so you don’t miss a talk, please fill out the **Google Form**. If you’re interested in presenting in a future session, you can submit the form or email me.
+
+
+# **Upcoming Talk**
+- **Talk-3**
+- **Date:** **January 16th, 2026, 10:30 AM CT**
+- **Title:** **"Multi-configuration state interaction methods in PySCF"**
+- **Presenter:** **Bhavnesh Jangid, University of Chicago**
+- **[Meeting link:]()**
+
+# Entire Schedule
+| Talk no. | Zoom link | Presenter | Date Time | Title | Institute |
+| 5 | Zoom Link | Rui Li | Nov 21st, 2025, 10:30 AM CT | Integration of the multigrid algorithm for efficient Fock build in PySCF with GPU acceleration | Caltech |
+| 4 | Zoom Link | Valay Agarawal | Feb 20th, 2026, 10:30 AM CT | Vendor independent GPU acceleration of multireference calculations with PySCF | Gagliardi Group, University of Chicago |
+| 3 | Zoom Link | Bhavnesh Jangid | Jan 16th, 2026, 10:30 AM CT | Multi-configuration state interaction methods in PySCF | Gagliardi Group, University of Chicago |
+| 2 | Zoom Link | Dr. Yu Jin | Dec 19th, 2025, 10:30 AM CT | Memory-efficient high-order coupled cluster implementations in PySCF | Flatiron Institute |
+| 1 | Zoom Link | Dr. Chenghan Li | Nov 21st, 2025, 10:30 AM CT | Accurate and Fast Periodic QM/MM for Large-scale Problems | Chan Group, Caltech |


### PR DESCRIPTION
In this PR, I have added the schedule, important links of the pyscf virtual seminar series.

Let me know for format changes or any other issues.

@sunqm 

Thanks